### PR TITLE
ugly poc

### DIFF
--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/PercentageDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/PercentageDiscountConfigurationType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
+use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
 
 /**
  * Percentage discount action configuration form type.
@@ -23,6 +24,19 @@ use Symfony\Component\Validator\Constraints\Type;
  */
 class PercentageDiscountConfigurationType extends AbstractType
 {
+    /**
+     * @var TaxonRepositoryInterface
+     */
+    private $taxonRepository;
+
+    /**
+     * @param TaxonRepositoryInterface $taxonRepository
+     */
+    public function __construct(TaxonRepositoryInterface $taxonRepository)
+    {
+        $this->taxonRepository = $taxonRepository;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -35,6 +49,14 @@ class PercentageDiscountConfigurationType extends AbstractType
                     new NotBlank(),
                     new Type(['type' => 'numeric']),
                 ],
+            ])
+            ->add('filters', 'sylius_taxon_from_identifier', [
+                'label' => 'sylius.form.promotion_rule.contains_taxon.taxon',
+                'class' => $this->taxonRepository->getClassName(),
+                'query_builder' => function () {
+                    return $this->taxonRepository->getFormQueryBuilder();
+                },
+                'identifier' => 'code'
             ])
         ;
     }

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
@@ -128,6 +128,7 @@
             <tag name="form.type" alias="sylius_promotion_action_fixed_discount_configuration" />
         </service>
         <service id="sylius.form.type.promotion_action.percentage_discount_configuration" class="%sylius.form.type.promotion_action.percentage_discount_configuration.class%">
+            <argument type="service" id="sylius.repository.taxon" />
             <tag name="form.type" alias="sylius_promotion_action_percentage_discount_configuration" />
         </service>
         <service id="sylius.form.type.promotion_coupon_to_code" class="%sylius.form.type.promotion_coupon_to_code.class%">

--- a/src/Sylius/Component/Core/Promotion/Filter/TaxonFilter.php
+++ b/src/Sylius/Component/Core/Promotion/Filter/TaxonFilter.php
@@ -24,13 +24,13 @@ class TaxonFilter implements FilterInterface
      */
     public function filter(array $items, array $configuration)
     {
-        if (!isset($configuration['filters']['taxons'])) {
+        if (!isset($configuration['taxons'])) {
             return $items;
         }
 
         $filteredItems = [];
         foreach ($items as $item) {
-            if ($this->hasProductValidTaxon($item->getProduct(), $configuration['filters']['taxons'])) {
+            if ($this->hasProductValidTaxon($item->getProduct(), $configuration['taxons'])) {
                 $filteredItems[] = $item;
             }
         }
@@ -44,10 +44,10 @@ class TaxonFilter implements FilterInterface
      *
      * @return bool
      */
-    private function hasProductValidTaxon(ProductInterface $product, array $taxons)
+    private function hasProductValidTaxon(ProductInterface $product, $taxons)
     {
         foreach ($product->getTaxons() as $taxon) {
-            if (in_array($taxon->getCode(), $taxons)) {
+            if ($taxon->getCode() === $taxons) {
                 return true;
             }
         }

--- a/src/Sylius/Component/Promotion/Model/Action.php
+++ b/src/Sylius/Component/Promotion/Model/Action.php
@@ -76,6 +76,27 @@ class Action implements ActionInterface
         $this->configuration = $configuration;
     }
 
+    public function setTaxons(array $taxons)
+    {
+        if (!empty($taxons))
+        {
+            foreach ($taxons as $taxon)
+            {
+                $this->configuration['filters']['taxons'][] = $taxon;
+            }
+        }
+    }
+
+    public function getTaxons()
+    {
+        if(isset($this->getConfiguration()['filters']['taxons']))
+        {
+            return $this->getConfiguration();
+        }
+
+        return [];
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Related tickets | mentioned in https://github.com/Sylius/Sylius/issues/5772 |
| License | MIT |

The promotion has been configured like this:
![image](https://cloud.githubusercontent.com/assets/5156054/18146826/77a5ef84-6fda-11e6-887d-9a7d04cf13f8.png)

The cart behavior is this:
![image](https://cloud.githubusercontent.com/assets/5156054/18146841/85314086-6fda-11e6-9c7e-895f4b7f8813.png)

The downside is I couldn't make this accept multiple taxons, therefor, to have a functional POC, I reduced it to only one taxon as a filter.

This means we can implement campaigns such as "if you have products from books taxon in cart, apply 10% item discount on products from books taxon", but we lack "if you have products from books taxon in cart, apply 10% item discount on products from books and mobile phone taxons".

Let's hope @vcraescu brings light to this :dancers: 
